### PR TITLE
Fix changing the sampling frequency of iio devices + Fix magnetometer calibration

### DIFF
--- a/adaptors/iioadaptor/iioadaptor.cpp
+++ b/adaptors/iioadaptor/iioadaptor.cpp
@@ -599,6 +599,22 @@ void IioAdaptor::processSample(int fileId, int fd)
 bool IioAdaptor::setInterval(const unsigned int value, const int sessionId)
 {
     if (mode() == SysfsAdaptor::IntervalMode)
+        if (value != 0) {
+            QString pathFreq = iioDevice.devicePath + "sampling_frequency";
+
+            float freq = 1000.0/value;
+            float out_freq = 1.0;
+
+            foreach(float valid_freq, iioDevice.frequencyList){
+                if (freq >= valid_freq){
+                    out_freq = valid_freq;
+                }                    
+            }
+
+            sysfsWriteInt(pathFreq, (int)out_freq);
+
+            qDebug() << iioDevice.name + ":" << "Frequency set to" << out_freq << "Hz";
+        }
         return SysfsAdaptor::setInterval(value, sessionId);
 
     sensordLogD() << "Ignoring setInterval for " << value;

--- a/adaptors/iioadaptor/iioadaptor.cpp
+++ b/adaptors/iioadaptor/iioadaptor.cpp
@@ -234,6 +234,7 @@ int IioAdaptor::findSensor(const QString &sensorName)
                 iioDevice.offset = 0.0;
                 iioDevice.scale = 1.0;
                 iioDevice.frequency = 1.0;
+                iioDevice.frequencyList = {1.0};
                 qDebug() << Q_FUNC_INFO << "Syspath for sensor (" + sensorName + "):" << iioDevice.devicePath;
 
                 udev_list_entry_foreach(sysattr, udev_device_get_sysattr_list_entry(dev)) {
@@ -261,6 +262,15 @@ int IioAdaptor::findSensor(const QString &sensorName)
                         iioDevice.frequency = QString(value).toDouble(&ok);
                         if (ok) {
                             qDebug() << sensorName + ":" << "Frequency is" << iioDevice.frequency;
+                        }
+                    } else if (attributeName.endsWith("frequency_available")) {                        
+                        iioDevice.frequencyList = {};
+
+                        foreach(QString freq, QString(value).split(" ")){
+                            iioDevice.frequencyList << freq.toDouble(&ok);
+                        }
+                        if (ok) {
+                            qDebug() << sensorName + ":" << "Frequency list is" << iioDevice.frequencyList;
                         }
                     } else if (attributeName.contains(QRegularExpression(iioDevice.channelTypeName + ".*raw$"))) {
                         qDebug() << "adding to paths:" << iioDevice.devicePath

--- a/adaptors/iioadaptor/iioadaptor.h
+++ b/adaptors/iioadaptor/iioadaptor.h
@@ -66,6 +66,7 @@ class IioAdaptor : public SysfsAdaptor
       qreal scale;
       qreal offset;
       int frequency;
+      QList<float> frequencyList;
       QString devicePath;
       int index;
       IioSensorType sensorType;

--- a/chains/magcalibrationchain/calibrationfilter.cpp
+++ b/chains/magcalibrationchain/calibrationfilter.cpp
@@ -114,10 +114,6 @@ void CalibrationFilter::magDataAvailable(unsigned, const CalibratedMagneticField
 
             transformed.level_ = calLevel;
 
-            transformed.x_ -= offsetX;
-            transformed.y_ -= offsetY;
-            transformed.z_ -= offsetZ;
-
             ///////////////////// soft iron
             qreal vmaxX = minMaxList.at(0).second - ((minMaxList.at(0).first + minMaxList.at(0).second) * 0.5);
             qreal vmaxY = minMaxList.at(1).second - ((minMaxList.at(1).first + minMaxList.at(1).second) * 0.5);
@@ -141,6 +137,10 @@ void CalibrationFilter::magDataAvailable(unsigned, const CalibratedMagneticField
             yScale = (avgRad/avgY);
             zScale = (avgRad/avgZ);
         }
+
+        transformed.x_ -= offsetX;
+        transformed.y_ -= offsetY;
+        transformed.z_ -= offsetZ;
 
         transformed.x_ *= xScale;
         transformed.y_ *= yScale;


### PR DESCRIPTION
Implements missing functionality in the iioadaptor for setting the sampling frequency of the device according to the "default_interval" value in milliseconds specified in the config file. 

Due to a limitation of the current implementation, this value is always truncated to an integer, thus preventing some frequencies from being set properly. For example, 80 Hz corresponds to 12.5 ms, which is truncated to 12 ms and then the computed frequency is instead 83 Hz (also after truncation). As a workaround, the frequency computed from "default_interval" is compared to the available frequencies advertised by the device driver, and the closest one from below (less or equal than) is chosen and written to the device file. 